### PR TITLE
add .gz suffix to backup tar file

### DIFF
--- a/github_backup.py
+++ b/github_backup.py
@@ -34,7 +34,7 @@ class GithubBackup:
             pool.join()
 
             self.logger.info("Creating archive")
-            with tarfile.open(destination_dir / "github-backup.tar", "w:gz") as tar:
+            with tarfile.open(destination_dir / "github-backup.tar.gz", "w:gz") as tar:
                 tar.add(self.tmpdir, arcname="github-backup")
 
     def clone_repo(self, repo):


### PR DESCRIPTION
as it's a gzipped compressed file, it's just adding the suffix. @orellazri 